### PR TITLE
try fixing getting desc_path

### DIFF
--- a/R/nix_hash.R
+++ b/R/nix_hash.R
@@ -92,7 +92,7 @@ hash_url <- function(url) {
   sri_hash <- nix_sri_hash(path = path_to_source_root)
 
   paths <- list.files(path_to_src, full.names = TRUE, recursive = TRUE)
-  desc_path <- grep("DESCRIPTION", paths, value = TRUE)
+  desc_path <- grep(file.path(list.files(path_to_src), "DESCRIPTION"), paths, value = TRUE)
 
   deps <- get_imports(desc_path)
 


### PR DESCRIPTION
https://github.com/ropensci/rix/issues/371

This fixes the problem that occurs when there are two Description files resulting in  two paths.
I tried to solve it in a rather generic way, by using `file.path(list.files(path_to_src), "DESCRIPTION")` so only allowing the description file if it's in the root folder. This solves the problem in my use-case, but  @b-rodrigues feel free to change and further test.