### PR TITLE
Fix handle remote deps

### DIFF
--- a/R/rix.R
+++ b/R/rix.R
@@ -284,6 +284,8 @@ for more details."
   flag_git_archive <- if (
     !is.null(git_pkgs) || !is.null(cran_pkgs$archive_pkgs)
   ) {
+    # If git_pkgs is a list of lists, then sapply will succeed
+    # if not, then we can access "package_name" directly
     git_pkgs_names <- if (!is.null(git_pkgs)) {
       tryCatch(
         sapply(git_pkgs, function(x) x$package_name),

--- a/R/rix.R
+++ b/R/rix.R
@@ -296,7 +296,6 @@ for more details."
     # so we need to split at the '@' character and then
     # walk through the list to grab the first element
     # which will be the name of the package
-    pkgs <- strsplit(cran_pkgs$archive_pkg, split = "@")
     cran_archive_names <- if (!is.null(cran_pkgs$archive_pkgs)) {
       pkgs <- strsplit(cran_pkgs$archive_pkgs, split = "@")
       sapply(pkgs, function(x) x[[1]])

--- a/R/rix.R
+++ b/R/rix.R
@@ -282,21 +282,21 @@ for more details."
 
   # If there are R packages from Git, passes the string "git_archive_pkgs" to buildInputs
   flag_git_archive <- if (
-    !is.null(cran_pkgs$archive_pkgs) || !is.null(git_pkgs)
+    !is.null(git_pkgs) || !is.null(cran_pkgs$archive_pkgs)
   ) {
-    # If git_pkgs is a list of lists, then sapply will succeed
-    # if not, then we can access "package_name" directly
-    git_pkgs_names <- tryCatch(
-      sapply(git_pkgs, function(x) x$package_name),
-      error = function(e) git_pkgs$package_name
-    )
-    # CRAN archive pkgs are written as "AER@123"
-    # so we need to split at the '@' character and then
-    # walk through the list to grab the first element
-    # which will be the name of the package
-    pkgs <- strsplit(cran_pkgs$archive_pkg, split = "@")
-    pkgs_names <- sapply(pkgs, function(x) x[[1]])
-    paste0(c(pkgs_names, git_pkgs_names), collapse = " ")
+    git_pkgs_names <- if (!is.null(git_pkgs)) {
+      tryCatch(
+        sapply(git_pkgs, function(x) x$package_name),
+        error = function(e) git_pkgs$package_name
+      )
+    }
+
+    cran_archive_names <- if (!is.null(cran_pkgs$archive_pkgs)) {
+      pkgs <- strsplit(cran_pkgs$archive_pkgs, split = "@")
+      sapply(pkgs, function(x) x[[1]])
+    }
+
+    paste0(c(git_pkgs_names, cran_archive_names), collapse = " ")
   } else {
     ""
   }

--- a/R/rix.R
+++ b/R/rix.R
@@ -290,7 +290,11 @@ for more details."
         error = function(e) git_pkgs$package_name
       )
     }
-
+    # CRAN archive pkgs are written as "AER@123"
+    # so we need to split at the '@' character and then
+    # walk through the list to grab the first element
+    # which will be the name of the package
+    pkgs <- strsplit(cran_pkgs$archive_pkg, split = "@")
     cran_archive_names <- if (!is.null(cran_pkgs$archive_pkgs)) {
       pkgs <- strsplit(cran_pkgs$archive_pkgs, split = "@")
       sapply(pkgs, function(x) x[[1]])


### PR DESCRIPTION
This fixes a bug introduced here: https://github.com/ropensci/rix/commit/44cf22a694257f094858d2c66bb0767fe58c28e9

Example. This used to work fine:

```
rix(
    r_ver = "4.3.1",
    r_pkgs = c("dplyr", "ggplot2"),
    ide = "code",
    project_path = ".",
    git_pkgs = list(
        package_name = "CSFAtasTools",
        repo_url = "https://github.com/mihem/CSFAtlasTools",
        commit = "02d485896d383e2a876f0f3bbae7265c017e7e92"
    ),
    overwrite = TRUE
)
```

But now failed with

```
Error in strsplit(cran_pkgs$archive_pkg, split = "@") : 
  non-character argument
```

In contrast, if there is a CRAN archive, this works fine:

```
rix(
    r_ver = "4.3.1",
    r_pkgs = c("dplyr", "ggplot2", "AER@1.2-8"),
    ide = "code",
    project_path = ".",
    git_pkgs = list(
        package_name = "CSFAtasTools",
        repo_url = "https://github.com/mihem/CSFAtlasTools",
        commit = "02d485896d383e2a876f0f3bbae7265c017e7e92"
    ),
    overwrite = TRUE
)
```

This should be fixed with this commit.

