### PR TITLE
Fix double installation remote packages

### DIFF
--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -359,23 +359,22 @@ fetchzips <- function(archive_pkgs) {
   }
 }
 
-#' fetchpkgs Downloads and installs packages hosted in the CRAN archives or
-#' Github.
-#' @param git_pkgs A list of three elements: "package_name", the name of the
-#' package, "repo_url", the repository's url and "commit", the commit hash of
-#' interest. This argument can also be a list of lists of these four elements.
-#' @param archive_pkgs A character, or an atomic vector of characters.
-#' @return A character. The Nix definition to download and build the R package
-#' from the CRAN archives.
+#' fetchpkgs Downloads and installs packages from CRAN archives or Github
+#' @param git_pkgs List of Git packages with name, url and commit
+#' @param archive_pkgs Vector of CRAN archive package names
+#' @return Nix definition string for building the packages
 #' @noRd
 fetchpkgs <- function(git_pkgs, archive_pkgs) {
-  # This removes all packages that are already included
-  # because they are remote packages from another package
-  remote_package_names <- unlist(lapply(git_pkgs, get_remote))
-  git_pkgs_names <- sapply(git_pkgs, `[[`, "package_name")
-  git_pkgs_name_corrected <- setdiff(git_pkgs_names, remote_package_names)
-  git_pkgs_corrected <- git_pkgs[sapply(git_pkgs, function(pkg) pkg$package_name %in% git_pkgs_name_corrected)]
-  paste(fetchgits(git_pkgs_corrected),
+  all_remotes <- unique(unlist(lapply(git_pkgs, get_remote)))
+  
+  # Only include git packages that aren't already remote dependencies
+  needed_git_pkgs <- git_pkgs[!sapply(git_pkgs, function(pkg) {
+    pkg$package_name %in% all_remotes
+  })]
+
+  # Combine git and archive package definitions
+  paste(
+    fetchgits(needed_git_pkgs),
     fetchzips(archive_pkgs),
     collapse = "\n"
   )

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -371,9 +371,10 @@ fetchzips <- function(archive_pkgs) {
 fetchpkgs <- function(git_pkgs, archive_pkgs) {
   # This removes all packages that are already included
   # because they are remote packages from another package
-  all_remote_package_names <- unlist(lapply(git_pkgs, get_remote))
-  package_names <- sapply(git_pkgs, `[[`, "package_name")
-  git_pkgs_corrected <- setdiff(package_names, all_remote_package_names)
+  remote_package_names <- unlist(lapply(git_pkgs, get_remote))
+  git_pkgs_names <- sapply(git_pkgs, `[[`, "package_name")
+  git_pkgs_name_corrected <- setdiff(git_pkgs_names, remote_package_names)
+  git_pkgs_corrected <- git_pkgs[sapply(git_pkgs, function(pkg) pkg$package_name %in% git_pkgs_name_corrected)]
   paste(fetchgits(git_pkgs_corrected),
     fetchzips(archive_pkgs),
     collapse = "\n"

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -375,7 +375,7 @@ fetchpkgs <- function(git_pkgs, archive_pkgs) {
 
   # Combine git and archive package definitions
   paste(
-    fetchgits(needed_git_pkgs),
+    fetchgits(git_pkgs),
     fetchzips(archive_pkgs),
     collapse = "\n"
   )

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -365,12 +365,13 @@ fetchzips <- function(archive_pkgs) {
 #' @return Nix definition string for building the packages
 #' @noRd
 fetchpkgs <- function(git_pkgs, archive_pkgs) {
-  all_remotes <- unique(unlist(lapply(git_pkgs, get_remote)))
-  
   # Only include git packages that aren't already remote dependencies
-  needed_git_pkgs <- git_pkgs[!sapply(git_pkgs, function(pkg) {
-    pkg$package_name %in% all_remotes
-  })]
+  if (all(sapply(git_pkgs, is.list))) {
+    all_remotes <- unique(unlist(lapply(git_pkgs, get_remote)))
+    git_pkgs <- git_pkgs[!sapply(git_pkgs, function(pkg) {
+      pkg$package_name %in% all_remotes
+    })]
+  }
 
   # Combine git and archive package definitions
   paste(


### PR DESCRIPTION
This tried to fix the following issue:

```
rix(
    r_ver = "4.3.1",
    r_pkgs = c("dplyr", "ggplot2", "AER@1.2-8"),
    # r_pkgs = c("dplyr", "ggplot2"),
    ide = "code",
    project_path = ".",
    git_pkgs = list(
        package_name = "CSFAtasTools",
        repo_url = "https://github.com/mihem/CSFAtlasTools",
        commit = "02d485896d383e2a876f0f3bbae7265c017e7e92"
    ),
    overwrite = TRUE
)
```

works fine.

But adding the remote dependency leads to a double entry of datathin

```
rix(
    r_ver = "4.3.1",
    r_pkgs = c("dplyr", "ggplot2"),
    ide = "code",
    project_path = ".",
    git_pkgs = list(
        list(
        package_name = "CSFAtasTools",
        repo_url = "https://github.com/mihem/CSFAtlasTools",
        commit = "02d485896d383e2a876f0f3bbae7265c017e7e92"
    ),
    list(
        package_name = "datathin",
        repo_url = "https://github.com/anna-neufeld/datathin",
        commit = "58eb154609365fa7301ea0fa397fbf04dd8c28ed"
    )
),
overwrite = TRUE
)
```

This runs fine, but then `nix-build` fails with:

```
error: attribute 'datathin' already defined at /home/mischko/develop/rix_remote_dependencies/default.nix:29:5
       at /home/mischko/develop/rix_remote_dependencies/default.nix:77:5:
           76|
           77|     datathin = (pkgs.rPackages.buildRPackage {
             |     ^
           78|       name = "datathin";
```

because default.nix contains `datathin` twice https://gist.github.com/mihem/5800eca94a429404161ccbe5a84732fe

So it's actually as easy as manually removing the second datathin entry. You could just tell the users not to call remote dependencies (plus it's less writing). However, problem occurs if you call `renv2nix`.

This took me quite some time to figure out and lots of trials. But now both of the above versions are working, including calling `renv2nix` using this renv.lock  https://gist.github.com/mihem/41844d478ead8c98e05646114cccbeb2 :)


