### PR TITLE
Fix rm vscode tmp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rix
 Title: Reproducible Data Science Environments with 'Nix'
-Version: 0.14.6
+Version: 0.14.7
 Authors@R: c(
     person(given = "Bruno", family = "Rodrigues", email = "bruno@brodrigues.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3211-3689")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+# rix 0.14.7 (2025-01-26)
+
+- `rix()`: fixed a bug where temp files necessary to VS Code were being removed 
+   (see https://github.com/ropensci/rix/pull/396)
+
 # rix 0.14.6 (2025-01-21)
 
 - `rix()`: fixed a bug where local packages were not being handled correctly

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -178,7 +178,7 @@ remove_base <- function(list_imports) {
 #' @return Atomic vector of packages
 #' @noRd
 get_imports <- function(path) {
-  tmpdir <- tempdir(), "rix_tmp")
+  tmpdir <- file.path(tempdir(), "rix_tmp")
   on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
 
   tmp_dir <- tempfile(pattern = "file", tmpdir = tmpdir, fileext = "")

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -178,7 +178,7 @@ remove_base <- function(list_imports) {
 #' @return Atomic vector of packages
 #' @noRd
 get_imports <- function(path) {
-  tmpdir <- tempdir()
+  tmpdir <- tempdir(), "rix_tmp")
   on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
 
   tmp_dir <- tempfile(pattern = "file", tmpdir = tmpdir, fileext = "")

--- a/R/nix_hash.R
+++ b/R/nix_hash.R
@@ -30,12 +30,15 @@ nix_hash <- function(repo_url, commit) {
 #' - `deps`: list with three elements: 'package', its 'imports' and its 'remotes'
 #' @noRd
 hash_url <- function(url) {
-  tdir <- tempdir()
+  # Create a specific subdirectory for our package's temp files
+  # this avoids removing existing tmp files
+  tdir <- file.path(tempdir(), "rix_tmp")
   on.exit(unlink(tdir, recursive = TRUE, force = TRUE), add = TRUE)
   tmpdir <- paste0(
-    tdir, "_repo_hash_url_",
+    tdir, "/repo_hash_url_",
     paste0(sample(letters, 5), collapse = "")
   )
+  dir.create(tmpdir, recursive = TRUE)
   on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
 
   path_to_folder <- tempfile(pattern = "file", tmpdir = tmpdir, fileext = "")


### PR DESCRIPTION
@b-rodrigues this fixes a bug i had since the beginning in vscode after running rix and took me some time to figure out.

```
Warning message:
In file(con, "w") :
  cannot open file '/tmp/RtmpRf8FWl/vscode-R/workspace.json': No such file or directory
```

So vscode-R saves tmp files in tempdir

```
print(list.files(tempdir(), recursive = TRUE))
[1] "vscode-R/addins.json"    "vscode-R/response.lock" 
[3] "vscode-R/response.log"   "vscode-R/workspace.json"
[5] "vscode-R/workspace.lock"
```

rix deletes tmp files that are created (which is good i think) but also deletes all other tmp files, e.g. these vscode-R files, which produce these warning in vscode-R.

I tried to fix this by creating a rix_tmp specific folder.
At least in my case this fixes this issue