### PR TITLE
Remote namespace

### DIFF
--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -274,6 +274,17 @@ get_imports <- function(path) {
   # Remove minimum package version for example 'packagename ( > 1.0.0)'
   output <- trimws(gsub("\\(.*?\\)", "", output))
 
+  # Get imports from NAMESPACE
+  namespace_path <- gsub("DESCRIPTION", "NAMESPACE", desc_path)
+  namespace_raw <- readLines(namespace_path)
+  namespace_imports <- namespace_raw[grepl("importFrom", namespace_raw)]
+  namespace_imports_pkgs <- gsub("importFrom\\(([^,]+).*", "\\1", namespace_imports)
+
+  if (length(namespace_imports_pkgs) > 0) {
+    namespace_imports_pkgs <- unique(namespace_imports_pkgs)
+    output <- union(output, namespace_imports_pkgs)
+  }
+
   output <- remove_base(unique(output))
 
   output <- gsub("\\.", "_", output)

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -278,10 +278,15 @@ get_imports <- function(path) {
   namespace_path <- gsub("DESCRIPTION", "NAMESPACE", desc_path)
   namespace_raw <- readLines(namespace_path)
   namespace_imports <- namespace_raw[grepl("importFrom", namespace_raw)]
-  namespace_imports_pkgs <- gsub("importFrom\\(([^,]+).*", "\\1", namespace_imports)
 
-  if (length(namespace_imports_pkgs) > 0) {
+  if (length(namespace_imports) > 0) {
+    # Get package names from `importFrom` statements
+    namespace_imports_pkgs <- gsub("importFrom\\(([^,]+).*", "\\1", namespace_imports)
+    # Remove quotes, which is sometimes necessary
+    # example: https://github.com/cran/AER/blob/master/NAMESPACE
+    namespace_imports_pkgs <- gsub("[\"']", "", namespace_imports_pkgs)
     namespace_imports_pkgs <- unique(namespace_imports_pkgs)
+    # combine imports from DESCRIPTION and NAMESPACE
     output <- union(output, namespace_imports_pkgs)
   }
 

--- a/tests/testthat/test-fetchers.R
+++ b/tests/testthat/test-fetchers.R
@@ -135,3 +135,30 @@ testthat::test_that("Test fetchgit gets a package with several remote deps and c
     "\n    httr2 = (pkgs.rPackages.buildRPackage {\n      name = \"httr2\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/b-rodrigues/httr2\";\n        rev = \"HEAD\";\n        sha256 = \"sha256-ny4J2WqUL4LPLWRKS8rgVqwvgMOQ2Rm/lbBWtF+99PE=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          cli\n          curl\n          glue\n          lifecycle\n          magrittr\n          openssl\n          R6\n          rappdirs\n          rlang\n          vctrs\n          withr;\n      };\n    });\n\n    gh = (pkgs.rPackages.buildRPackage {\n      name = \"gh\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/b-rodrigues/gh\";\n        rev = \"HEAD\";\n        sha256 = \"sha256-POXEMZv8kqHokAxK8LoWkS0qYrcIcVdQi5xyGD992KU=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          cli\n          gitcreds\n          glue\n          ini\n          jsonlite\n          lifecycle\n          rlang;\n      } ++ [ httr2 ];\n    });\n\n\n    highlite = (pkgs.rPackages.buildRPackage {\n      name = \"highlite\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/jimhester/highlite\";\n        rev = \"HEAD\";\n        sha256 = \"sha256-lkWMlAi75MYxiBUYnLwxLK9ApXkWanA4Mt7g4qtLpxM=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          Rcpp\n          BH;\n      };\n    });\n\n\n    memoise = (pkgs.rPackages.buildRPackage {\n      name = \"memoise\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/b-rodrigues/memoise\";\n        rev = \"74d62c8\";\n        sha256 = \"sha256-fsdop66VglkOIYrJ0LKZKikIZmzQ2gqEATLy9tTJ/B8=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          digest;\n      };\n    });\n\n    lookup = (pkgs.rPackages.buildRPackage {\n      name = \"lookup\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/b-rodrigues/lookup/\";\n        rev = \"ee5505c817b19b59d37236ed35a81a65aa376124\";\n        sha256 = \"sha256-jiSBuC1vzJbN6OckgVX0E+XuMCeZS5LKsldIVL7DNgo=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          Rcpp\n          codetools\n          crayon\n          rex\n          jsonlite\n          rstudioapi\n          withr\n          httr;\n      } ++ [ highlite gh memoise ];\n    });\n"
   )
 })
+
+testthat::test_that("Test fetchgit gets a package that is not listed in DESCRIPTION, only in NAMESPACE", {
+  testthat::skip_on_cran()
+  testthat::expect_equal(
+    fetchgit(
+      list(
+        package_name = "seurat-data",
+        repo_url = "https://github.com/satijalab/seurat-data",
+        commit = "4dc08e022f51c324bc7bf785b1b5771d2742701d"
+      )
+    ),
+    "\n    seurat-data = (pkgs.rPackages.buildRPackage {\n      name = \"seurat-data\";\n      src = pkgs.fetchgit {\n        url = \"https://github.com/satijalab/seurat-data\";\n        rev = \"4dc08e022f51c324bc7bf785b1b5771d2742701d\";\n        sha256 = \"sha256-dyv8ttrVaGwd5tPle2+wDHMa8lVjozZnVMsKArEMTPE=\";\n      };\n      propagatedBuildInputs = builtins.attrValues {\n        inherit (pkgs.rPackages) \n          cli\n          crayon\n          rappdirs\n          SeuratObject\n          Matrix\n          Seurat;\n      };\n    });\n"
+  )
+})
+
+testthat::test_that("Test fetchgit works even if there are not `importfrom` in NAMESPACE", {
+  testthat::skip_on_cran()
+  testthat::expect_no_error(
+    fetchgit(
+      list(
+        package_name = "CSFAtlasTools",
+        repo_url = "https://github.com/mihem/CSFAtlasTools",
+        commit = "ac4a34d39812e8b8fa5746b63df4cf321a13b7a7"
+      )
+    )
+  )
+})


### PR DESCRIPTION
@b-rodrigues This tries to implement our idea to also include imports from NAMESPACE; not only from DESCRIPTION.

This was actually easier than I thought. I might have missed something, but the tests seems to pass.
I added tests, one checks if `Seurat` is fetched in `seurat-data`, which we added manually before that because it's not listed in DESCRIPTION.

I fixed a bug which happens because e.g. this CRAN mirror uses quotes. 
https://github.com/cran/AER/blob/master/NAMESPACE

Excited about your revision.