### PR TITLE
Fix r profile

### DIFF
--- a/R/rix_init.R
+++ b/R/rix_init.R
@@ -138,9 +138,10 @@ rix_init <- function(project_path,
   # first create the call, deparse it, and write it to .Rprofile
   rprofile_quoted <- nix_rprofile()
   rprofile_deparsed <- deparse_chr1(expr = rprofile_quoted, collapse = "\n")
+  rprofile_cleaned <- gsub(pattern = "^\\{|\\}$", replacement = "", x = rprofile_deparsed)
   rprofile_file <- file.path(project_path, ".Rprofile")
 
-  rprofile_text <- get_rprofile_text(rprofile_deparsed)
+  rprofile_text <- get_rprofile_text(rprofile_cleaned)
 
   # This function creates the connection, write the text
   # and closes the connection
@@ -418,7 +419,7 @@ set_nix_path <- function() {
 #' @noRd
 nix_rprofile <- function() {
   # nolint start: object_name_linter
-  quote(
+  quote({
     is_rstudio <- Sys.getenv("RSTUDIO") == "1"
     is_nix_r <- nzchar(Sys.getenv("NIX_STORE"))
     is_code <- Sys.getenv("TERM_PROGRAM") == "vscode"
@@ -483,10 +484,10 @@ nix_rprofile <- function() {
       rm(current_paths, userlib_paths, user_dir, new_paths)
     }
 
-    rm(is_rstudio, is_nix_r)
     if (isTRUE(is_code) && interactive() && isFALSE(is_rstudio)) {
         source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))
     }
-  )
+    rm(is_rstudio, is_nix_r, is_code)
+  })
   # nolint end: object_name
 }

--- a/R/rix_init.R
+++ b/R/rix_init.R
@@ -418,9 +418,10 @@ set_nix_path <- function() {
 #' @noRd
 nix_rprofile <- function() {
   # nolint start: object_name_linter
-  quote({
+  quote(
     is_rstudio <- Sys.getenv("RSTUDIO") == "1"
     is_nix_r <- nzchar(Sys.getenv("NIX_STORE"))
+    is_code <- Sys.getenv("TERM_PROGRAM") == "vscode"
     if (isFALSE(is_nix_r) && isTRUE(is_rstudio)) {
       # Currently, RStudio does not propagate environmental variables defined in
       # `$HOME/.zshrc`, `$HOME/.bashrc` and alike. This is workaround to
@@ -483,6 +484,9 @@ nix_rprofile <- function() {
     }
 
     rm(is_rstudio, is_nix_r)
-  })
+    if (isTRUE(is_code) && interactive() && isFALSE(is_rstudio)) {
+        source(file.path(Sys.getenv(if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"), ".vscode-R", "init.R"))
+    }
+  )
   # nolint end: object_name
 }


### PR DESCRIPTION
@b-rodrigues I found that the resulting .Rprofile has some curly braces which prevent functions to work.

```
{
    is_rstudio <- Sys.getenv("RSTUDIO") == "1"
...
    rm(is_rstudio, is_nix_r)
}
```

So I could call `install.packages()` and there was not stop message.
Getting rid of the curly braces was quite difficult. Tried using expression or using subsitute but that did not work. So in the end i justed used gsub to remove them. Maybe not very elegant, but at least works. I tested that in my case it raises the expected error message. Not sure we can create a unit test for that, because it's testing the resulting environment?

Additionally, vscode-R did not work properly, `.vsc.attach` did not work and functionalities like `View` did not work.
https://github.com/REditorSupport/vscode-R/issues/1094

So I added the necessary source lines. I put this in an if statement only evaluating if the editor is vscode, so I think this should not mess up anything.

Looking forward to your feedback.
