### PR TITLE
Remove excessive unlinks

### DIFF
--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -217,27 +217,26 @@ get_imports <- function(path) {
     # to only keep packagename
     remotes <- gsub("\n", "", x = unlist(strsplit(remotes$Remotes, ",")))
     # Get user names
-    remote_pkgs_usernames <- strsplit(remotes, "/") |>
-      sapply(function(x) x[[1]])
+    remote_pkgs_usernames <- sapply(strsplit(remotes, "/"), function(x) x[[1]])
 
     # Now remove user name and
     # split at "@" or "#" character to get name and commit or PR separated
     remote_pkgs_names_and_refs <- sub(".*?/", "", remotes)
     remote_pkgs_names_and_refs <- strsplit(remote_pkgs_names_and_refs, "(@|#)")
 
-    remote_pkgs_names <- remote_pkgs_names_and_refs |>
-      sapply(function(x) x[[1]])
+    remote_pkgs_names <- sapply(remote_pkgs_names_and_refs, function(x) x[[1]])
 
     # Check if we have a list of lists of two elements: a package name
     # and a ref. If not, add "HEAD" to it.
-    remote_pkgs_refs <- lapply(remote_pkgs_names_and_refs, function(sublist) {
+    out <- lapply(remote_pkgs_names_and_refs, function(sublist) {
       if (length(sublist) == 1) {
         c(sublist, "HEAD")
       } else {
         sublist
       }
-    }) |>
-      sapply(function(x) x[[2]])
+    })
+
+    remote_pkgs_refs <- sapply(out, function(x) x[[2]])
 
     urls <- paste0(
       "https://github.com/",

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -179,16 +179,11 @@ remove_base <- function(list_imports) {
 #' @noRd
 get_imports <- function(path) {
   tmpdir <- tempdir()
-  on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
 
   tmp_dir <- tempfile(pattern = "file", tmpdir = tmpdir, fileext = "")
   if (!dir.exists(tmp_dir)) {
     dir.create(tmp_dir, recursive = TRUE)
   }
-  on.exit(
-    unlink(tmp_dir, recursive = TRUE, force = TRUE),
-    add = TRUE
-  )
 
   # Some packages have a Description file in the testthat folder
   # (see jimhester/lookup) so we need to get rid of that

--- a/R/nix_hash.R
+++ b/R/nix_hash.R
@@ -31,34 +31,23 @@ nix_hash <- function(repo_url, commit) {
 #' @noRd
 hash_url <- function(url) {
   tdir <- tempdir()
-  on.exit(unlink(tdir, recursive = TRUE, force = TRUE), add = TRUE)
+
   tmpdir <- paste0(
     tdir, "_repo_hash_url_",
     paste0(sample(letters, 5), collapse = "")
   )
-  on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
 
   path_to_folder <- tempfile(pattern = "file", tmpdir = tmpdir, fileext = "")
   dir.create(path_to_folder, recursive = TRUE)
-  on.exit(
-    unlink(path_to_folder, recursive = TRUE, force = TRUE),
-    add = TRUE
-  )
 
   path_to_tarfile <- paste0(path_to_folder, "/package_tar_gz")
   path_to_src <- paste0(path_to_folder, "/package_src")
 
   dir.create(path_to_src, recursive = TRUE)
   path_to_src <- normalizePath(path_to_src)
-  on.exit(
-    unlink(path_to_src, recursive = TRUE, force = TRUE),
-    add = TRUE
-  )
+
   dir.create(path_to_tarfile, recursive = TRUE)
-  on.exit(
-    unlink(path_to_tarfile, recursive = TRUE, force = TRUE),
-    add = TRUE
-  )
+
   path_to_tarfile <- normalizePath(path_to_tarfile)
 
   h <- curl::new_handle(failonerror = TRUE, followlocation = TRUE)

--- a/R/rix_helpers.R
+++ b/R/rix_helpers.R
@@ -198,8 +198,7 @@ generate_tex_pkgs <- function(tex_pkgs) {
 #' @noRd
 get_system_pkgs <- function(system_pkgs, r_pkgs) {
   # We always need these packages
-  system_pkgs <- c(system_pkgs, "R", "glibcLocales", "nix") |>
-    sort()
+  system_pkgs <- sort(c(system_pkgs, "R", "glibcLocales", "nix"))
 
   # If the user wants the R {quarto} package, then the quarto software needs to
   # be installed

--- a/R/with_nix.R
+++ b/R/with_nix.R
@@ -233,12 +233,12 @@ with_nix <- function(expr,
     # 1) save all function args onto a temporary folder each with
     # `<tag.Rds>` and `value` as serialized objects from RAM -------------------
     tmpdir <- tempdir()
-    on.exit(unlink(tmpdir, recursive = TRUE, force = TRUE), add = TRUE)
+
     temp_dir <- file.path(tmpdir, "with_nix")
     if (!dir.exists(temp_dir)) {
       dir.create(temp_dir, recursive = TRUE)
     }
-    on.exit(unlink(temp_dir, recursive = TRUE, force = TRUE), add = TRUE)
+
     serialize_args(args, temp_dir)
 
     # cast list of symbols/names and calls to list of strings; this is to prepare
@@ -353,18 +353,6 @@ with_nix <- function(expr,
     }
   }
   cat("")
-
-  on.exit(
-    {
-      if (program == "R") {
-        unlink(temp_dir, recursive = TRUE, force = TRUE)
-        # only R expressions are nonblockings
-        tools::pskill(pid = proc)
-      }
-    },
-    after = FALSE,
-    add = TRUE
-  )
 
   return(out)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -405,7 +405,7 @@ Finally, thanks to [David Solito](https://www.davidsolito.com/about/) for creati
 
 - [NixOS’s website](https://nixos.org/)
 - [Nixpkgs’s GitHub repository](https://github.com/NixOS/nixpkgs)
-- [Nix for R series from Bruno's blog](https://www.brodrigues.co/tags/nix/). Or, in case you like video tutorials, watch [this one on Reproducible R development environments with Nix](https://www.youtube.com/watch?v=c1LhgeTTxaI)
+- [Nix for R series from Bruno's blog](https://brodrigues.co/index.html#category=nix). Or, in case you like video tutorials, watch [this one on Reproducible R development environments with Nix](https://www.youtube.com/watch?v=c1LhgeTTxaI)
 - [nix.dev tutorials](https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs#pinning-nixpkgs)
 - [INRIA's Nix tutorial](https://nix-tutorial.gitlabpages.inria.fr/nix-tutorial/installation.html)
 - [Nix pills](https://nixos.org/guides/nix-pills/)

--- a/README.md
+++ b/README.md
@@ -404,9 +404,9 @@ for creating `{rix}`’s logo!
 - [NixOS’s website](https://nixos.org/)
 - [Nixpkgs’s GitHub repository](https://github.com/NixOS/nixpkgs)
 - [Nix for R series from Bruno’s
-  blog](https://www.brodrigues.co/tags/nix/). Or, in case you like video
-  tutorials, watch [this one on Reproducible R development environments
-  with Nix](https://www.youtube.com/watch?v=c1LhgeTTxaI)
+  blog](https://brodrigues.co/index.html#category=nix). Or, in case you
+  like video tutorials, watch [this one on Reproducible R development
+  environments with Nix](https://www.youtube.com/watch?v=c1LhgeTTxaI)
 - [nix.dev
   tutorials](https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs#pinning-nixpkgs)
 - [INRIA’s Nix


### PR DESCRIPTION
I wonder if instead of #396 we shouldn't be instead removing all of this. It's ok to keep files in the temporary directories, what's not ok is:

- writing to the user directory and keeping the files there
- tests or vignettes that write to the user directory and keep the detritus there

I think that this approach would be saner.