### PR TITLE
Flatten buildInputs to avoid nixpkgs 26.05 nested-list deprecation warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rix
 Title: Reproducible Data Science Environments with 'Nix'
-Version: 0.18.3
+Version: 0.18.4
 Authors@R: c(
     person(given = "Bruno", family = "Rodrigues", email = "bruno@brodrigues.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-3211-3689")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
+# rix 0.18.4 (2026-08-25)
+
+## Maintenance
+
+- `rix()`: generated `buildInputs` and IDE wrapper `packages` lists are now
+  wrapped in `pkgs.lib.flatten`, avoiding the nixpkgs 26.05 nested-list
+  deprecation warning.
+
 # rix 0.18.3 (2026-06-26)
 
 ## New features

--- a/R/rix_helpers.R
+++ b/R/rix_helpers.R
@@ -486,7 +486,7 @@ generate_wrapped_pkgs <- function(
     sprintf(
       "
   wrapped_pkgs = pkgs.%s.override {
-    packages = [ %s %s %s ];
+    packages = pkgs.lib.flatten [ %s %s %s ];
   };
 ",
       attrib[ide],
@@ -549,7 +549,7 @@ generate_shell <- function(
     %s
     %s
     %s
-    buildInputs = [ %s %s %s %s %s system_packages %s %s ];
+    buildInputs = pkgs.lib.flatten [ %s %s %s %s %s system_packages %s %s ];
     %s
   };",
       generate_locale_archive(detect_os()),


### PR DESCRIPTION
Hi Bruno and Philipp,

Evaluating a `default.nix` generated by `rix()` against a nixpkgs pin ≥ 26.05 prints:

```
evaluation warning: Dependency of package 'nix-shell' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```

The cause is that `rpkgs`, `system_packages`, `pyconf`, etc. are lists, so `buildInputs = [ rpkgs system_packages ... ]` is a list of lists. The IDE wrapper has the same shape (`packages = [ rpkgs ]`).

**Change**

Two lines in `R/rix_helpers.R`, wrapping both in `pkgs.lib.flatten`:

```nix
buildInputs = pkgs.lib.flatten [ rpkgs tex system_packages wrapped_pkgs ];
packages    = pkgs.lib.flatten [ rpkgs ];
```

`lib.flatten` handles the mix of lists and single derivations, and empty slots.

**Checks**

- `nix-instantiate` against the 2026-08-24 pin: R + TeX + RStudio goes from 3 warnings to 0. GitHub package + Python + Positron: 0.
- Older pins (2021-10-28 with R 4.1.1, and 2024-12-14) still evaluate fine.
- The resulting shell is unchanged, with the same R, git and nix store paths before and after.
- Test suite passes after `testthat::snapshot_accept()`, and every snapshot differs only in these two lines. I left the snapshot updates out to keep the diff minimal, but I'm happy to push them if you prefer.

Not tested: actually launching an RStudio/Positron wrapper (only evaluated to a `.drv`).

Existing projects are unaffected since they pin an older nixpkgs.

Let me know if I am wrong with this.

Thanks!
