### PR TITLE
Fix parsing of Depends: R when version spec has no space

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rix 0.18.6 (2026-xx-xx) 
 
+## Bug fixes
+
+- `get_imports()`: R listed in `Depends` is now removed regardless of spacing
+  (e.g., `Depends: R(>= 3.4)`), and packages with names ending in "R" are no
+  longer accidentally dropped.
+
 
 # rix 0.18.5 (2026-08-26)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - `get_imports()`: R listed in `Depends` is now removed regardless of spacing
   (e.g., `Depends: R(>= 3.4)`), and packages with names ending in "R" are no
-  longer accidentally dropped.
+  longer accidentally dropped. By @felipelfv, see #642. 
 
 
 # rix 0.18.5 (2026-08-26)

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -393,12 +393,9 @@ get_imports <- function(path, commit_date, ...) {
     output <- character(0)
   }
 
-  # Remove minimum package version for example 'packagename ( > 1.0.0)'
-  output <- trimws(gsub("\\(.*?\\)", "", output))
-
-  # Remove R itself, which may be listed in 'Depends' with or without
-  # a version spec, spaced or not: 'R', 'R (>= 3.4)', 'R(>= 3.4)'
-  output <- Filter(function(x) x != "R", output)
+  # Remove minimum package versions, e.g. 'pkg (>= 1.0.0)', and drop R itself,
+  # which may be listed in 'Depends' with or without a version spec
+  output <- Filter(function(x) x != "R", trimws(gsub("\\(.*?\\)", "", output)))
 
   # Get imports from NAMESPACE
   namespace_path <- gsub("DESCRIPTION", "NAMESPACE", desc_path)

--- a/R/fetchers.R
+++ b/R/fetchers.R
@@ -393,11 +393,12 @@ get_imports <- function(path, commit_date, ...) {
     output <- character(0)
   }
 
-  # Remove version of R that may be listed in 'Depends'
-  output <- Filter(function(x) !grepl("R \\(.*\\)", x), output)
-
   # Remove minimum package version for example 'packagename ( > 1.0.0)'
   output <- trimws(gsub("\\(.*?\\)", "", output))
+
+  # Remove R itself, which may be listed in 'Depends' with or without
+  # a version spec, spaced or not: 'R', 'R (>= 3.4)', 'R(>= 3.4)'
+  output <- Filter(function(x) x != "R", output)
 
   # Get imports from NAMESPACE
   namespace_path <- gsub("DESCRIPTION", "NAMESPACE", desc_path)

--- a/tests/testthat/test-fetchers.R
+++ b/tests/testthat/test-fetchers.R
@@ -457,3 +457,24 @@ testthat::test_that("Private repos with HTTPS URL throw error", {
     "Private repositories require SSH URLs"
   )
 })
+
+testthat::test_that("get_imports drops R from Depends regardless of spacing", {
+  # 'Depends: R(...)' may lack a space before the parenthesis (e.g. lavaan),
+  # which used to leak a bare 'R' into the generated dependency list.
+  make_fixture <- function(depends) {
+    dir <- tempfile("depends_fixture")
+    dir.create(dir)
+    writeLines(
+      c("Package: fakepkg", "Version: 1.0.0", paste("Depends:", depends)),
+      file.path(dir, "DESCRIPTION")
+    )
+    writeLines("import(MASS)", file.path(dir, "NAMESPACE"))
+    file.path(dir, "DESCRIPTION")
+  }
+
+  for (depends in c("R(>= 3.4), MASS", "R (>= 4.0), MASS", "R, MASS")) {
+    result <- get_imports(make_fixture(depends), commit_date = "2026-08-01")
+    testthat::expect_false("R" %in% result$imports, info = depends)
+    testthat::expect_true("MASS" %in% result$imports, info = depends)
+  }
+})

--- a/tests/testthat/test-fetchers.R
+++ b/tests/testthat/test-fetchers.R
@@ -458,23 +458,58 @@ testthat::test_that("Private repos with HTTPS URL throw error", {
   )
 })
 
-testthat::test_that("get_imports drops R from Depends regardless of spacing", {
-  # 'Depends: R(...)' may lack a space before the parenthesis (e.g. lavaan),
-  # which used to leak a bare 'R' into the generated dependency list.
-  make_fixture <- function(depends) {
-    dir <- tempfile("depends_fixture")
-    dir.create(dir)
-    writeLines(
-      c("Package: fakepkg", "Version: 1.0.0", paste("Depends:", depends)),
-      file.path(dir, "DESCRIPTION")
-    )
-    writeLines("import(MASS)", file.path(dir, "NAMESPACE"))
+# builds a minimal package fixture with the given 'Depends' field and no
+# NAMESPACE imports, so get_imports() output comes from 'Depends' alone.
+make_fixture <- function(depends) {
+  dir <- tempfile("depends_fixture")
+  dir.create(dir)
+  writeLines(
+    c("Package: fakepkg", "Version: 1.0.0", paste("Depends:", depends)),
     file.path(dir, "DESCRIPTION")
-  }
+  )
+  writeLines('exportPattern("^[[:alpha:]]+")', file.path(dir, "NAMESPACE"))
+  file.path(dir, "DESCRIPTION")
+}
 
-  for (depends in c("R(>= 3.4), MASS", "R (>= 4.0), MASS", "R, MASS")) {
-    result <- get_imports(make_fixture(depends), commit_date = "2026-08-01")
-    testthat::expect_false("R" %in% result$imports, info = depends)
-    testthat::expect_true("MASS" %in% result$imports, info = depends)
-  }
+testthat::test_that("get_imports drops R from Depends with spaced version", {
+  result <- get_imports(
+    make_fixture("R (>= 3.4), MASS"),
+    commit_date = "2026-08-01"
+  )
+  testthat::expect_identical(result$imports, "MASS")
+})
+
+testthat::test_that("get_imports drops R from Depends with unspaced version", {
+  # e.g. lavaan declares 'Depends: R(>= 3.4)', which used to leak a
+  # bare 'R' into the generated dependency list
+  result <- get_imports(
+    make_fixture("R(>= 3.4), MASS"),
+    commit_date = "2026-08-01"
+  )
+  testthat::expect_identical(result$imports, "MASS")
+})
+
+testthat::test_that("get_imports drops R from Depends without version", {
+  result <- get_imports(
+    make_fixture("R, MASS"),
+    commit_date = "2026-08-01"
+  )
+  testthat::expect_identical(result$imports, "MASS")
+})
+
+testthat::test_that("get_imports keeps packages whose name ends in R", {
+  # 'AER' ends in 'R' and must not be mistaken for the R dependency
+  result <- get_imports(
+    make_fixture("R (>= 3.4), AER (>= 3.4), MASS"),
+    commit_date = "2026-08-01"
+  )
+  testthat::expect_identical(result$imports, c("AER", "MASS"))
+})
+
+testthat::test_that("get_imports keeps ends-in-R packages with unspaced version", {
+  result <- get_imports(
+    make_fixture("R(>= 3.4), AER(>= 3.4)"),
+    commit_date = "2026-08-01"
+  )
+  testthat::expect_identical(result$imports, "AER")
 })


### PR DESCRIPTION
Hi Bruno, this is not necessarily a rix issue but something we can easily avoid on rix's side.

Some R packages declare `Depends: R(>= 3.4)`, so no space before the parenthesis. The filter in `get_imports()` only matched the spaced form, so a bare `R` leaked into the generated dependency list, breaking the build (`R` isn't in `rPackages`).

Fix: strip version specs first, then drop `R` exactly — covers `R`, `R (>= 3.4)`, and `R(>= 3.4)`.

Currently in draft because technically this is not a new feature, but maybe you still would want a test? Let me know.
